### PR TITLE
`features` parameter type changed from `File` to `String`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+## 0.3.0 [2023-08-23]
+Changed: `features` parameter type from `File` to `String`
 
 ## 0.2.0 [2023-07-31]
 Added: A vidarrworkflow name used for testing only 

--- a/smallBamQc.wdl
+++ b/smallBamQc.wdl
@@ -6,7 +6,7 @@ workflow smallBamQc {
         Int opticalDuplicatePixelDistance
         String outputFileNamePrefix
         Int? bedtoolsReadsToUse
-        File? features
+        String? features  # This is a file path, but using the `File` type doesn't play well with Shesmu/Vidarr type system
         Int? featuresToUse
         Int? picardMarkDuplicatesReadsToUse
         Int? samtoolsStatsReadsToUse
@@ -323,7 +323,7 @@ task markDuplicates {
 
 task featuresHead {
     input {
-        File features
+        String features
         Int? featuresToUse
         String modules = ""
         Float memory = 0.1
@@ -375,7 +375,7 @@ task featuresHead {
 task bedtoolsCoverageFull {
     input {
         File bam
-        File? features
+        String? features
         String outputFileNamePrefix
         String modules = "bedtools/2.27 samtools/1.16.1"
         Int memory = 4
@@ -435,7 +435,7 @@ task bedtoolsCoverageFull {
 task bedtoolsCoverageSmall {
     input {
         File bam
-        File? features
+        String? features
         Int readsToUse
         String outputFileNamePrefix
         String modules = "bedtools/2.27 samtools/1.16.1"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -70,18 +70,7 @@
             "smallBamQc.bedtoolsCoverageSmall.threads": null,
             "smallBamQc.bedtoolsCoverageSmall.timeout": null,
             "smallBamQc.bedtoolsReadsToUse": 1,
-            "smallBamQc.features": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
+            "smallBamQc.features": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
             "smallBamQc.featuresHead.memory": null,
             "smallBamQc.featuresHead.modules": null,
             "smallBamQc.featuresHead.threads": null,
@@ -185,18 +174,7 @@
             "smallBamQc.bedtoolsCoverageSmall.threads": null,
             "smallBamQc.bedtoolsCoverageSmall.timeout": null,
             "smallBamQc.bedtoolsReadsToUse": 0,
-            "smallBamQc.features": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
+            "smallBamQc.features": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
             "smallBamQc.featuresHead.memory": null,
             "smallBamQc.featuresHead.modules": null,
             "smallBamQc.featuresHead.threads": null,
@@ -300,18 +278,7 @@
             "smallBamQc.bedtoolsCoverageSmall.threads": null,
             "smallBamQc.bedtoolsCoverageSmall.timeout": null,
             "smallBamQc.bedtoolsReadsToUse": null,
-            "smallBamQc.features": {
-                "contents": {
-                    "configuration": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
-                    "externalIds": [
-                        {
-                            "id": "TEST",
-                            "provider": "TEST"
-                        }
-                    ]
-                },
-                "type": "EXTERNAL"
-            },
+            "smallBamQc.features": "/.mounts/labs/gsi/testdata/smallBamQc/input_data/EVOLVE-CHARM.TS.hg38.bed",
             "smallBamQc.featuresHead.memory": null,
             "smallBamQc.featuresHead.modules": null,
             "smallBamQc.featuresHead.threads": null,


### PR DESCRIPTION
`File` type doesn't work with Vidarr, as that implies as internal file tracked by Vidarr. As interval file aren't being tracked by Vidarr, a `String` type that specifies a path is the way to go.