### PR TITLE
Remove explicit handling of non-primary reads in samtools stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+Changed: Removed explicit filtering out of non-primary and supplementary reads from samtools stats. It does it by default.
+
 ## 0.3.0 [2023-08-23]
 Changed: `features` parameter type from `File` to `String`
 

--- a/smallBamQc.wdl
+++ b/smallBamQc.wdl
@@ -145,9 +145,8 @@ task samtoolsStatsSmall {
     command <<<
         set -euo pipefail
         # Non-primary reads (same read aligned multipe times) and supplementary reads (same read split up and each split aligned indpendantly) are excluded
-        # They will still be counted (filtered out column), but won't be used for other statistics
-        # This ensures the total read count of samtools stats matches the total reads produced by the machine
-        samtools head -n ~{readsToUse} --threads ~{threads} ~{bam} | samtools stats -F 2304 - > ~{outputFileNamePrefix}.stats.txt
+        # from samtools stats by defaut. This ensures the total read count of samtools stats matches the total reads produced by the machine
+        samtools head -n ~{readsToUse} --threads ~{threads} ~{bam} | samtools stats - > ~{outputFileNamePrefix}.stats.txt
     >>>
 
     output {
@@ -191,9 +190,8 @@ task samtoolsStatsFull {
     command <<<
         set -euo pipefail
         # Non-primary reads (same read aligned multipe times) and supplementary reads (same read split up and each split aligned indpendantly) are excluded
-        # They will still be counted (filtered out column), but won't be used for other statistics
-        # This ensures the total read count of samtools stats matches the total reads produced by the machine
-        samtools stats -F 2304 --threads ~{threads} ~{bam} > ~{outputFileNamePrefix}.stats.txt
+        # from samtools stats by default. This ensures the total read count of samtools stats matches the total reads produced by the machine
+        samtools stats --threads ~{threads} ~{bam} > ~{outputFileNamePrefix}.stats.txt
     >>>
 
     output {


### PR DESCRIPTION
Non-primary reads have been one of the bane of our existence, causing double counting of reads during analysis. Originally, I just excluded all reads that could result in double counting. I removed this because A) samtools stats already does this B) my explicit exclusion strategy lumped non-primary and supplementary reads together. samtools stats excludes them but counts them separately.